### PR TITLE
Added 'show info' command and allowed user to use . or / 

### DIFF
--- a/lib/IntruKit.py
+++ b/lib/IntruKit.py
@@ -92,7 +92,7 @@ class IntruKit(Cmd):
         try:
             if self.__mh.Instance:
                 self.__mh.unload()
-                self.__mh = None
+                # self.__mh = None
                 self.prompt = '{}ikit{}> '.format(colors.OKGREEN, colors.ENDC)
         except:
             print("No module loaded.")
@@ -112,7 +112,7 @@ class IntruKit(Cmd):
     def do_show(self, args):
         """
         Command: show <type>
-        Description: Show something. Supports: modules, options
+        Description: Show something. Supports: modules, options, info (requires loaded module)
         """
         try:
             if 'options' in args.lower():
@@ -168,6 +168,25 @@ class IntruKit(Cmd):
                                                            str(self.__mh.Instance.__rank__).ljust(12),
                                                            str(self.__mh.Instance.__description__)).ljust(26))
                                 self.__mh.unload()
+                print("\n")
+            elif 'info' in args:
+                print("\n")
+                print("{}{}".format(colors.OKGREEN, 'About'.ljust(28)))
+                print("{}".format('______\n'.ljust(28)))
+
+                print("{}Title: {}{}".format(colors.OKGREEN, colors.ENDC, str(self.__mh.Instance.__title__)))
+                print("{}Last Updated: {}{}".format(colors.OKGREEN, colors.ENDC, str(self.__mh.Instance.__date__)))
+                print("{}Rank: {}{}".format(colors.OKGREEN, colors.ENDC, str(self.__mh.Instance.__rank__)))
+
+                print("{}{}".format(colors.OKGREEN, '\nDescription'.ljust(28)))
+                print("{}".format('______\n'.ljust(28)))
+
+                print("{}{}".format(colors.ENDC, str(self.__mh.Instance.__description__)))
+
+                print("{}{}".format(colors.OKGREEN, '\nDetails'.ljust(28)))
+                print("{}".format('______\n'.ljust(28)))
+
+                print("{}{}".format(colors.ENDC, str(self.__mh.Instance.__details__)))
                 print("\n")
         except Exception as e:
             print(e)

--- a/lib/ModuleHandler.py
+++ b/lib/ModuleHandler.py
@@ -20,16 +20,16 @@ class ModuleHandler():
         """
         self.Instance = Instance
 
-    def use(self, Module="example.hello_world"):
+    def use(self, Module="example/hello_world"):
         """
-        use(self, Module="example.hello_world")
+        use(self, Module="example/hello_world")
         
         :param Module: 
         :return: 
         
         Use a specific module as an Instance. The example.hello_world is used as default
         """
-        M = importlib.import_module("modules.{}".format(Module))
+        M = importlib.import_module("modules.{}".format(Module.replace("/", ".")))
         Mod = getattr(M, 'Module')
         Instance = Mod()
         self.Instance = Instance


### PR DESCRIPTION
… when calling to use a module. Ex: use example.hello_world or use example/hello_world